### PR TITLE
Enable user enquiry comments

### DIFF
--- a/src/components/EnquiryComments.tsx
+++ b/src/components/EnquiryComments.tsx
@@ -1,0 +1,299 @@
+import React, { useState, useEffect } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+import { useToast } from '@/hooks/use-toast';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Badge } from '@/components/ui/badge';
+import { MessageSquare, Send, Trash2, User, UserCheck, Clock } from 'lucide-react';
+import { format } from 'date-fns';
+import { Enquiry, EnquiryComment } from '@/types/enquiries';
+
+interface EnquiryCommentsProps {
+  enquiry: Enquiry;
+  currentUserId: string;
+  isEmployee: boolean;
+  onClose: () => void;
+}
+
+const EnquiryComments: React.FC<EnquiryCommentsProps> = ({ 
+  enquiry, 
+  currentUserId, 
+  isEmployee,
+  onClose 
+}) => {
+  const { toast } = useToast();
+  const [comments, setComments] = useState<EnquiryComment[]>([]);
+  const [newComment, setNewComment] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    loadComments();
+  }, [enquiry.id]);
+
+  const loadComments = async () => {
+    try {
+      setLoading(true);
+      
+      // Fetch comments
+      const { data: commentsData, error: commentsError } = await supabase
+        .from('enquiry_comments')
+        .select('*')
+        .eq('enquiry_id', enquiry.id)
+        .order('created_at', { ascending: true });
+
+      if (commentsError) throw commentsError;
+
+      // Fetch profiles for comment authors
+      if (commentsData && commentsData.length > 0) {
+        const userIds = [...new Set(commentsData.map(c => c.user_id))];
+        const { data: profilesData, error: profilesError } = await supabase
+          .from('profiles')
+          .select('user_id, full_name, role')
+          .in('user_id', userIds);
+
+        if (profilesError) throw profilesError;
+
+        // Map profiles to comments
+        const commentsWithProfiles = commentsData.map(comment => ({
+          ...comment,
+          profiles: profilesData?.find(p => p.user_id === comment.user_id) || null
+        }));
+
+        setComments(commentsWithProfiles as EnquiryComment[]);
+      } else {
+        setComments([]);
+      }
+    } catch (error) {
+      console.error('Error loading comments:', error);
+      toast({
+        title: "Error",
+        description: "Failed to load comments",
+        variant: "destructive",
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSubmitComment = async () => {
+    if (!newComment.trim()) {
+      toast({
+        title: "Error",
+        description: "Please enter a comment",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    try {
+      setSubmitting(true);
+      const { error } = await supabase
+        .from('enquiry_comments')
+        .insert({
+          enquiry_id: enquiry.id,
+          user_id: currentUserId,
+          comment: newComment.trim(),
+        });
+
+      if (error) throw error;
+
+      setNewComment('');
+      await loadComments();
+      
+      toast({
+        title: "Success",
+        description: "Comment added successfully",
+      });
+    } catch (error) {
+      console.error('Error creating comment:', error);
+      toast({
+        title: "Error",
+        description: "Failed to add comment",
+        variant: "destructive",
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleDeleteComment = async (commentId: string) => {
+    try {
+      const { error } = await supabase
+        .from('enquiry_comments')
+        .delete()
+        .eq('id', commentId);
+
+      if (error) throw error;
+
+      await loadComments();
+      toast({
+        title: "Success",
+        description: "Comment deleted successfully",
+      });
+    } catch (error) {
+      console.error('Error deleting comment:', error);
+      toast({
+        title: "Error",
+        description: "Failed to delete comment",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const formatDate = (dateString: string) => {
+    return format(new Date(dateString), 'MMM dd, yyyy • HH:mm');
+  };
+
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case 'resolved': return 'bg-green-100 text-green-800';
+      case 'open': return 'bg-yellow-100 text-yellow-800';
+      default: return 'bg-gray-100 text-gray-800';
+    }
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto p-6 space-y-6">
+      {/* Header */}
+      <div className="flex items-start justify-between">
+        <div className="space-y-2">
+          <div className="flex items-center gap-3">
+            <h1 className="text-2xl font-bold">{enquiry.subject}</h1>
+            <Badge className={getStatusColor(enquiry.status)}>
+              {enquiry.status}
+            </Badge>
+          </div>
+          <div className="flex items-center gap-4 text-sm text-muted-foreground">
+            <div className="flex items-center gap-1">
+              <User className="h-4 w-4" />
+              <span>{enquiry.profiles?.full_name}</span>
+            </div>
+            <div className="flex items-center gap-1">
+              <Clock className="h-4 w-4" />
+              <span>{formatDate(enquiry.created_at)}</span>
+            </div>
+          </div>
+        </div>
+        <Button variant="outline" onClick={onClose}>
+          Close
+        </Button>
+      </div>
+
+      {/* Original Enquiry */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <MessageSquare className="h-5 w-5" />
+            Original Enquiry
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="p-4 bg-secondary/20 rounded-lg">
+            <p className="text-sm leading-relaxed">{enquiry.message}</p>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Comments Thread */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <MessageSquare className="h-5 w-5" />
+            Comments ({comments.length})
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {loading ? (
+            <div className="text-center py-8">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-4"></div>
+              <p className="text-muted-foreground">Loading comments...</p>
+            </div>
+          ) : comments.length === 0 ? (
+            <div className="text-center py-8 text-muted-foreground">
+              <MessageSquare className="h-12 w-12 mx-auto mb-4 opacity-50" />
+              <p>No comments yet. Start the conversation!</p>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {comments.map((comment, index) => (
+                <div key={comment.id} className="space-y-3">
+                  <div className="flex items-start justify-between p-4 bg-background border rounded-lg">
+                    <div className="flex-1 space-y-2">
+                      <div className="flex items-center gap-3">
+                        <div className="flex items-center gap-2">
+                          {comment.profiles?.role === 'employee' ? (
+                            <UserCheck className="h-4 w-4 text-primary" />
+                          ) : (
+                            <User className="h-4 w-4 text-muted-foreground" />
+                          )}
+                          <span className="font-medium text-sm">
+                            {comment.profiles?.full_name}
+                          </span>
+                          {comment.profiles?.role === 'employee' && (
+                            <Badge variant="secondary" className="text-xs">
+                              Employee
+                            </Badge>
+                          )}
+                        </div>
+                        <span className="text-xs text-muted-foreground">
+                          {formatDate(comment.created_at)}
+                        </span>
+                      </div>
+                      <p className="text-sm leading-relaxed">{comment.comment}</p>
+                    </div>
+                    {(comment.user_id === currentUserId || isEmployee) && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleDeleteComment(comment.id)}
+                        className="text-destructive hover:text-destructive"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Add Comment Form */}
+          <div className="border-t pt-4 space-y-4">
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Add a comment</label>
+              <Textarea
+                value={newComment}
+                onChange={(e) => setNewComment(e.target.value)}
+                placeholder="Type your comment here..."
+                className="min-h-20"
+              />
+            </div>
+            <div className="flex justify-end">
+              <Button 
+                onClick={handleSubmitComment}
+                disabled={submitting || !newComment.trim()}
+                size="sm"
+              >
+                {submitting ? (
+                  <>
+                    <Clock className="h-4 w-4 mr-2 animate-spin" />
+                    Adding...
+                  </>
+                ) : (
+                  <>
+                    <Send className="h-4 w-4 mr-2" />
+                    Add Comment
+                  </>
+                )}
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default EnquiryComments;

--- a/src/components/EnquiryList.tsx
+++ b/src/components/EnquiryList.tsx
@@ -1,26 +1,6 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { useAuth } from '@/components/AuthContext';
-import { supabase } from '@/integrations/supabase/client';
-import { useToast } from '@/hooks/use-toast';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { 
-  MessageSquare, 
-  Calendar,
-  CheckCircle,
-  Clock,
-  Loader2
-} from 'lucide-react';
-import { format } from 'date-fns';
-
-interface Enquiry {
-  id: string;
-  subject: string;
-  message: string;
-  status: 'open' | 'resolved';
-  created_at: string;
-}
+import EnquiryManagement from './EnquiryManagement';
 
 interface EnquiryListProps {
   refresh?: number;
@@ -28,102 +8,13 @@ interface EnquiryListProps {
 
 const EnquiryList: React.FC<EnquiryListProps> = ({ refresh }) => {
   const { user } = useAuth();
-  const { toast } = useToast();
-  const [enquiries, setEnquiries] = useState<Enquiry[]>([]);
-  const [loading, setLoading] = useState(true);
-
-  const fetchEnquiries = async () => {
-    if (!user) return;
-
-    try {
-      const { data, error } = await supabase
-        .from('enquiries')
-        .select('*')
-        .eq('user_id', user.id)
-        .order('created_at', { ascending: false });
-
-      if (error) throw error;
-      setEnquiries((data || []) as Enquiry[]);
-    } catch (error: any) {
-      toast({
-        title: "Failed to load enquiries",
-        description: error.message,
-        variant: "destructive"
-      });
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    fetchEnquiries();
-  }, [user, refresh]);
-
-  const getStatusColor = (status: string) => {
-    return status === 'resolved' 
-      ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
-      : 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200';
-  };
-
-  const getStatusIcon = (status: string) => {
-    return status === 'resolved' ? CheckCircle : Clock;
-  };
-
-  if (loading) {
-    return (
-      <Card>
-        <CardContent className="flex items-center justify-center py-8">
-          <Loader2 className="h-6 w-6 animate-spin mr-2" />
-          Loading enquiries...
-        </CardContent>
-      </Card>
-    );
-  }
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          <MessageSquare className="h-5 w-5" />
-          My Enquiries ({enquiries.length})
-        </CardTitle>
-      </CardHeader>
-      <CardContent>
-        {enquiries.length === 0 ? (
-          <div className="text-center py-8 text-muted-foreground">
-            <MessageSquare className="h-12 w-12 mx-auto mb-4 opacity-50" />
-            <p>No enquiries submitted yet</p>
-            <p className="text-sm">Submit your first enquiry to get help</p>
-          </div>
-        ) : (
-          <div className="space-y-4">
-            {enquiries.map((enquiry) => {
-              const StatusIcon = getStatusIcon(enquiry.status);
-              return (
-                <div key={enquiry.id} className="border rounded-lg p-4 hover:bg-muted/50 transition-colors">
-                  <div className="flex items-start justify-between mb-2">
-                    <h3 className="font-medium">{enquiry.subject}</h3>
-                    <Badge className={getStatusColor(enquiry.status)}>
-                      <StatusIcon className="w-3 h-3 mr-1" />
-                      {enquiry.status}
-                    </Badge>
-                  </div>
-                  
-                  <p className="text-sm text-muted-foreground mb-2 line-clamp-2">
-                    {enquiry.message}
-                  </p>
-                  
-                  <div className="flex items-center gap-1 text-xs text-muted-foreground">
-                    <Calendar className="h-3 w-3" />
-                    {format(new Date(enquiry.created_at), 'MMM dd, yyyy • HH:mm')}
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        )}
-      </CardContent>
-    </Card>
+    <EnquiryManagement 
+      userId={user?.id} 
+      currentUserId={user?.id}
+      isEmployee={false}
+    />
   );
 };
 

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -318,6 +318,33 @@ export type Database = {
         }
         Relationships: []
       }
+      enquiry_comments: {
+        Row: {
+          comment: string
+          created_at: string
+          enquiry_id: string
+          id: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          comment: string
+          created_at?: string
+          enquiry_id: string
+          id?: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          comment?: string
+          created_at?: string
+          enquiry_id?: string
+          id?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
       lor_responses: {
         Row: {
           communication_skills: string | null

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -239,7 +239,7 @@ const Dashboard = () => {
               <TabsTrigger value="overview">Overview</TabsTrigger>
               <TabsTrigger value="applications">Applications</TabsTrigger>
               <TabsTrigger value="documents">Documents</TabsTrigger>
-              <TabsTrigger value="communications">Communications</TabsTrigger>
+              <TabsTrigger value="communications">Enquiries</TabsTrigger>
               <TabsTrigger value="tasks">Tasks</TabsTrigger>
               <TabsTrigger value="timeline">Timeline</TabsTrigger>
             </TabsList>
@@ -493,7 +493,7 @@ const Dashboard = () => {
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
                     <MessageSquare className="h-5 w-5" />
-                    Communications
+                    Enquiries
                   </CardTitle>
                 </CardHeader>
                 <CardContent>

--- a/src/pages/EmployeeDashboard.tsx
+++ b/src/pages/EmployeeDashboard.tsx
@@ -16,6 +16,7 @@ import { format } from 'date-fns';
 import DocumentDownloadManager from '@/components/DocumentDownloadManager';
 import { TaskList } from '@/components/TaskList';
 import { CreateTaskModal } from '@/components/CreateTaskModal';
+import EnquiryManagement from '@/components/EnquiryManagement';
 
 interface User {
   id: string;
@@ -541,23 +542,6 @@ const EmployeeDashboard = () => {
     }
   };
 
-  const handleUpdateEnquiryStatus = async (enquiryId: string, newStatus: 'open' | 'resolved') => {
-    const { error } = await supabase
-      .from('enquiries')
-      .update({ 
-        status: newStatus,
-        updated_at: new Date().toISOString()
-      })
-      .eq('id', enquiryId);
-
-    if (error) {
-      console.error('Error updating enquiry status:', error);
-      toast({ title: "Error", description: "Failed to update enquiry status", variant: "destructive" });
-    } else {
-      toast({ title: "Success", description: "Enquiry status updated successfully" });
-      fetchUserData(selectedUserId);
-    }
-  };
 
   const getStatusBadge = (status: string) => {
     const statusMap = {
@@ -570,15 +554,6 @@ const EmployeeDashboard = () => {
     return <Badge variant={statusInfo.variant}>{statusInfo.label}</Badge>;
   };
 
-  const getEnquiryStatusColor = (status: string) => {
-    return status === 'resolved' 
-      ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
-      : 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200';
-  };
-
-  const getEnquiryStatusIcon = (status: string) => {
-    return status === 'resolved' ? CheckCircle : Clock;
-  };
 
   const formatFileSize = (bytes: number) => {
     if (bytes === 0) return '0 Bytes';
@@ -1303,58 +1278,11 @@ const EmployeeDashboard = () => {
                   </TabsContent>
 
                   <TabsContent value="enquiries" className="space-y-4">
-                    <Card>
-                      <CardHeader>
-                        <CardTitle className="flex items-center gap-2">
-                          <MessageSquare className="h-4 w-4" />
-                          Student Enquiries ({enquiries.length})
-                        </CardTitle>
-                      </CardHeader>
-                      <CardContent>
-                        {enquiries.length === 0 ? (
-                          <div className="text-center py-8 text-muted-foreground">
-                            <MessageSquare className="h-12 w-12 mx-auto mb-4 opacity-50" />
-                            <p>No enquiries submitted by this student</p>
-                          </div>
-                        ) : (
-                          <div className="space-y-4">
-                            {enquiries.map((enquiry) => {
-                              const StatusIcon = getEnquiryStatusIcon(enquiry.status);
-                              return (
-                                <div key={enquiry.id} className="border rounded-lg p-4">
-                                  <div className="flex items-start justify-between mb-2">
-                                    <h3 className="font-medium">{enquiry.subject}</h3>
-                                    <div className="flex items-center gap-2">
-                                      <Badge className={getEnquiryStatusColor(enquiry.status)}>
-                                        <StatusIcon className="w-3 h-3 mr-1" />
-                                        {enquiry.status}
-                                      </Badge>
-                                      {enquiry.status === 'open' && (
-                                        <Button
-                                          size="sm"
-                                          onClick={() => handleUpdateEnquiryStatus(enquiry.id, 'resolved')}
-                                        >
-                                          Mark Resolved
-                                        </Button>
-                                      )}
-                                    </div>
-                                  </div>
-                                  
-                                  <p className="text-sm text-muted-foreground mb-2">
-                                    {enquiry.message}
-                                  </p>
-                                  
-                                  <div className="flex items-center gap-1 text-xs text-muted-foreground">
-                                    <Calendar className="h-3 w-3" />
-                                    {format(new Date(enquiry.created_at), 'MMM dd, yyyy • HH:mm')}
-                                  </div>
-                                </div>
-                              );
-                            })}
-                          </div>
-                        )}
-                      </CardContent>
-                    </Card>
+                    <EnquiryManagement 
+                      userId={selectedUserId} 
+                      currentUserId={user?.id}
+                      isEmployee={true}
+                    />
                   </TabsContent>
 
                   <TabsContent value="questionnaire" className="space-y-4">

--- a/src/types/enquiries.ts
+++ b/src/types/enquiries.ts
@@ -1,0 +1,34 @@
+export interface Enquiry {
+  id: string;
+  user_id: string;
+  subject: string;
+  message: string;
+  status: 'open' | 'resolved';
+  created_at: string;
+  updated_at: string;
+  profiles?: {
+    full_name: string;
+    role?: string;
+  };
+  comments?: EnquiryComment[];
+  comments_count?: number;
+}
+
+export interface EnquiryComment {
+  id: string;
+  enquiry_id: string;
+  user_id: string;
+  comment: string;
+  created_at: string;
+  updated_at: string;
+  profiles?: {
+    full_name: string;
+    role: string;
+  };
+}
+
+export interface CreateEnquiryCommentRequest {
+  enquiry_id: string;
+  comment: string;
+  user_id: string;
+}

--- a/supabase/migrations/20250831104228_35d5cf98-2fb2-4278-a508-d0d92474fd7c.sql
+++ b/supabase/migrations/20250831104228_35d5cf98-2fb2-4278-a508-d0d92474fd7c.sql
@@ -1,0 +1,67 @@
+-- Create enquiry_comments table for threaded conversations
+CREATE TABLE public.enquiry_comments (
+  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  enquiry_id UUID NOT NULL,
+  user_id UUID NOT NULL,
+  comment TEXT NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+-- Enable Row Level Security
+ALTER TABLE public.enquiry_comments ENABLE ROW LEVEL SECURITY;
+
+-- Create policies for enquiry comments
+CREATE POLICY "Users can view comments on their enquiries" 
+ON public.enquiry_comments 
+FOR SELECT 
+USING (
+  EXISTS (
+    SELECT 1 
+    FROM public.enquiries 
+    WHERE enquiries.id = enquiry_comments.enquiry_id 
+    AND enquiries.user_id = auth.uid()
+  )
+);
+
+CREATE POLICY "Employees can view all enquiry comments" 
+ON public.enquiry_comments 
+FOR SELECT 
+USING (is_employee(auth.uid()));
+
+CREATE POLICY "Users can comment on their enquiries" 
+ON public.enquiry_comments 
+FOR INSERT 
+WITH CHECK (
+  EXISTS (
+    SELECT 1 
+    FROM public.enquiries 
+    WHERE enquiries.id = enquiry_comments.enquiry_id 
+    AND enquiries.user_id = auth.uid()
+  ) AND auth.uid() = user_id
+);
+
+CREATE POLICY "Employees can comment on any enquiry" 
+ON public.enquiry_comments 
+FOR INSERT 
+WITH CHECK (is_employee(auth.uid()) AND auth.uid() = user_id);
+
+CREATE POLICY "Users can update their own comments" 
+ON public.enquiry_comments 
+FOR UPDATE 
+USING (auth.uid() = user_id)
+WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users and employees can delete comments" 
+ON public.enquiry_comments 
+FOR DELETE 
+USING (
+  (auth.uid() = user_id) OR 
+  is_employee(auth.uid())
+);
+
+-- Create trigger for automatic timestamp updates
+CREATE TRIGGER update_enquiry_comments_updated_at
+BEFORE UPDATE ON public.enquiry_comments
+FOR EACH ROW
+EXECUTE FUNCTION public.update_updated_at_column();


### PR DESCRIPTION
## Summary
- Show "My Enquiries" and user-friendly description in enquiry management header
- Allow students to open comment threads while restricting response/status controls to employees

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type @typescript-eslint/no-explicit-any)*

------
https://chatgpt.com/codex/tasks/task_e_68b42a575aa48323bc6493981ce3acee